### PR TITLE
Add opensmtpd to SERVICES list

### DIFF
--- a/cmd/acmetool/quickstart.go
+++ b/cmd/acmetool/quickstart.go
@@ -116,7 +116,7 @@ set -e
 EVENT_NAME="$1"
 [ "$EVENT_NAME" = "live-updated" ] || exit 42
 
-SERVICES="httpd apache2 apache nginx tengine lighttpd postfix dovecot exim exim4 haproxy hitch quassel quasselcore"
+SERVICES="httpd apache2 apache nginx tengine lighttpd postfix dovecot exim exim4 haproxy hitch quassel quasselcore opensmtpd"
 [ -e "/etc/default/acme-reload" ] && . /etc/default/acme-reload
 [ -e "/etc/conf.d/acme-reload" ] && . /etc/conf.d/acme-reload
 [ -z "$ACME_STATE_DIR" ] && ACME_STATE_DIR="@@ACME_STATE_DIR@@"


### PR DESCRIPTION
This pull request adds opensmtpd to the list of services that should
be restarted after certificate changes.